### PR TITLE
Update FileUpload.vue, fix for  "_vm.getFileErrors(...).join is not a function" error 

### DIFF
--- a/hub-ui/src/components/forms/FileUpload.vue
+++ b/hub-ui/src/components/forms/FileUpload.vue
@@ -18,7 +18,7 @@
               </div>
           </div>
           <div v-if="!!getFileErrors(file.id)">
-            <span class="text-sm text-red-600">{{ getFileErrors(file.id).join(',') }}</span>
+            <span class="text-sm text-red-600">{{ (Array.isArray(getFileErrors(file.id)))?getFileErrors(file.id).join(','):getFileErrors(file.id) }}</span>
           </div>
           <div v-if="!getFileErrors(file.id)">
           </div>


### PR DESCRIPTION
Fix for issue: https://github.com/getcandy/hub/issues/53
Check if an array of errors is returned or  a String.