### PR TITLE
Call `setValue` method instead of emitting event.

### DIFF
--- a/hub-core/src/components/hub/LocalisedAttributes.vue
+++ b/hub-core/src/components/hub/LocalisedAttributes.vue
@@ -36,7 +36,7 @@
         v-if="attribute.type == 'richtext'"
         :value="getValue(attribute.handle)"
         @input="setValue(attribute.handle, $event)"
-        @change="(value) => $emit('change', value)"
+        @change="setValue(attribute.handle, $event)"
       />
 
       <!-- <gc-input


### PR DESCRIPTION
This PR looks to bring the `@change` event on the RichText component to be the same as the `@input` event. They both submit the same data when called and looks like this is currently causing an issue when updating text, meaning the changes aren't propagated to the `attribute_data`