### PR TITLE
Strip out commas for price input

### DIFF
--- a/hub-ui/src/components/forms/PriceInput.vue
+++ b/hub-ui/src/components/forms/PriceInput.vue
@@ -51,7 +51,7 @@ export default {
   },
   computed: {
     formattedValue () {
-      return this.$format.currency(this.value, this.currency, this.isCents, false)
+      return this.$format.currency(this.value, this.currency, this.isCents, false).replace(',', '')
     }
   }
 }


### PR DESCRIPTION
Currently if you have a thousand separator in the price input it will cause an issue and won't display.

This PR looks to remove the `,` if it exists in the price string.