### PR TITLE
Map into attribute data if empty

### DIFF
--- a/hub-categories/src/pages/edit/CategoryDetails.vue
+++ b/hub-categories/src/pages/edit/CategoryDetails.vue
@@ -80,6 +80,14 @@ export default {
         if (attribute.group && !exists) {
           groups.push(attribute.group.data)
         }
+
+        if (!data.attribute_data[attribute.handle]) {
+          this.$set(data.attribute_data, attribute.handle, {
+            [this.channel]: {
+              en: ''
+            }
+          })
+        }
       })
 
       groups = orderBy(groups, 'position', 'asc')


### PR DESCRIPTION
Currently if you add a new attribute for a category in the database, it won't be mapped in the attributes when editing a category that doesn't have it set.

This PR uses the same check on products to determine if it exists and if it doesn't, puts an empty value in.